### PR TITLE
fix: restore owned pending queue and cancel on widget destruction

### DIFF
--- a/include/reactive/Computations.h
+++ b/include/reactive/Computations.h
@@ -13,6 +13,7 @@ namespace Reactive
     Computations();
     virtual ~Computations();
     void add(std::function<void()> &&cb) const;
+    void cancelPending() const;
 
    private:
     std::shared_ptr<ComputationsImpl> m_impl;

--- a/src/Computations.cpp
+++ b/src/Computations.cpp
@@ -9,11 +9,20 @@ namespace Reactive
   {
   }
 
-  Computations::~Computations() = default;
+  Computations::~Computations()
+  {
+    if(m_impl)
+      m_impl->cancelPending();
+  }
 
   void Computations::add(std::function<void()> &&cb) const
   {
     m_impl->add(std::move(cb));
+  }
+
+  void Computations::cancelPending() const
+  {
+    m_impl->cancelPending();
   }
 
 }

--- a/src/ComputationsImpl.cpp
+++ b/src/ComputationsImpl.cpp
@@ -18,38 +18,48 @@ namespace Reactive
 
   void ComputationsImpl::invalidate(Computation *c)
   {
-    const bool wasEmpty = m_pending.empty();
+    if(const auto it = m_computations.find(c); it != m_computations.end())
+    {
+      auto node = std::move(it->second);
+      auto *raw = node.get();
+      m_computations.erase(it);
 
-    m_pending.insert({ c->getDepth(), c });
+      const bool wasEmpty = m_pendingOrder.empty();
+      m_pending.emplace(raw, std::move(node));
+      m_pendingOrder.insert({ raw->getDepth(), raw });
 
-    if(wasEmpty && !m_pending.empty())
-      Deferrer::add(shared_from_this());
+      if(wasEmpty)
+        Deferrer::add(shared_from_this());
+    }
   }
 
   void ComputationsImpl::resolveDirtynessDownstream()
   {
   }
 
+  void ComputationsImpl::cancelPending()
+  {
+    m_pendingOrder.clear();
+    m_pending.clear();
+  }
+
   void ComputationsImpl::doDeferred(Computation *c)
   {
-    m_pending.erase({ c->getDepth(), c });
-
-    auto it = m_computations.find(c);
-
-    if(it != m_computations.end())
+    if(const auto it = m_pending.find(c); it != m_pending.end())
     {
-      auto cb = std::move(c->expropriateCallback());
-      m_computations.erase(it);
+      m_pendingOrder.erase({ c->getDepth(), c });
+      auto cb = std::move(it->second->expropriateCallback());
+      m_pending.erase(it);
       add(std::move(cb));
     }
   }
 
   Computation *ComputationsImpl::getLowest(Computation *lowestSoFar) const
   {
-    if(m_pending.empty())
+    if(m_pendingOrder.empty())
       return lowestSoFar;
 
-    auto *my = m_pending.begin()->second;
+    auto *my = m_pendingOrder.begin()->second;
 
     if(!lowestSoFar)
       return my;

--- a/src/ComputationsImpl.h
+++ b/src/ComputationsImpl.h
@@ -21,19 +21,15 @@ namespace Reactive
     virtual ~ComputationsImpl();
 
     void add(std::function<void()> &&cb);
+    void cancelPending();
     void invalidate(Computation *c) override;
     void resolveDirtynessDownstream() override;
     void doDeferred(Computation *c) override;
     Computation *getLowest(Computation *lowestSoFar) const override;
 
    private:
-    // Ownership of all live computations, keyed by pointer for O(1) lookup. The previous
-    // implementation moved unique_ptrs between two vectors and located them with a linear
-    // std::find_if on every invalidate/doDeferred - O(n) per call, O(n^2) when a whole
-    // batch (e.g. all step LEDs) is invalidated at once. Here ownership is stable and the
-    // dirty set is kept ordered by (depth, pointer) so the lowest-depth pending computation
-    // is the first element.
     std::unordered_map<Computation *, std::unique_ptr<Computation>> m_computations;
-    std::set<std::pair<uint32_t, Computation *>> m_pending;
+    std::unordered_map<Computation *, std::unique_ptr<Computation>> m_pending;
+    std::set<std::pair<uint32_t, Computation *>> m_pendingOrder;
   };
 }

--- a/tests/OrderingTests.cpp
+++ b/tests/OrderingTests.cpp
@@ -169,3 +169,49 @@ TEST_CASE("two independent latch chains of different depth in one batch")
   CHECK(deepResult == 8);   // 7 + 1
   CHECK(flatResult == 14);  // 7 * 2
 }
+
+TEST_CASE("destroying computations before deferrer flush drops pending callbacks")
+{
+  Var<int> v { 0 };
+  int runs = 0;
+
+  {
+    Deferrer deferrer;
+    {
+      Computations widget;
+      widget.add(
+          [&]
+          {
+            runs++;
+            (void)v.get();
+          });
+      REQUIRE(runs == 1);
+      v = 1;
+    }
+  }
+
+  CHECK(runs == 1);
+}
+
+TEST_CASE("cancelPending drops deferred callbacks without running them")
+{
+  Var<int> v { 0 };
+  int runs = 0;
+
+  auto widget = std::make_unique<Computations>();
+  widget->add(
+      [&]
+      {
+        runs++;
+        (void)v.get();
+      });
+  REQUIRE(runs == 1);
+
+  {
+    Deferrer deferrer;
+    v = 1;
+    widget->cancelPending();
+  }
+
+  CHECK(runs == 1);
+}


### PR DESCRIPTION
e010b83 kept raw pointers in the pending set while computations stayed in m_computations, so deferred callbacks could run after the owning widget was destroyed. Move invalidated computations into an owned pending map again and drop pending work from ~Computations via cancelPending().