### PR TITLE
Computations.h: include <cstdint> for uint32_t

### DIFF
--- a/include/reactive/Computations.h
+++ b/include/reactive/Computations.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <memory>
+#include <cstdint>
 
 namespace Reactive
 {


### PR DESCRIPTION
Newer GCC/libstdc++ no longer provide `uint32_t` transitively via `<functional>`/`<memory>`; on current Arch GCC the header fails to compile. One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)