### PR TITLE
fix: include <cstdint> for uint32_t in Computations.h

### DIFF
--- a/include/reactive/Computations.h
+++ b/include/reactive/Computations.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 


### PR DESCRIPTION
`Computations::add(std::function<void()>&&, uint32_t depth)` uses `uint32_t`, but `Computations.h` only includes `<functional>` and `<memory>`. On GCC (Arch) `<cstdint>` isn't pulled in transitively, so the header fails to compile:

```
error: 'uint32_t' has not been declared
```

Add the missing `#include <cstdint>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)